### PR TITLE
Updated py3 support matrix

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -5,11 +5,17 @@
       jobs:
         - tox-pep8
         - tox-py27
+        - tox-py35
+        - tox-py36
+        - tox-py37
         - dlrn-api-functional
     gate:
       jobs:
         - tox-pep8
         - tox-py27
+        - tox-py35
+        - tox-py36
+        - tox-py37
         - dlrn-api-functional
     release:
       jobs:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,9 @@
 [metadata]
 name = dlrnapi_client
 summary = Client for DLRN REST API
+project_urls =
+    Bug Tracker = https://github.com/softwarefactory-project/dlrnapi_client/issues
+    Source Code = https://github.com/softwarefactory-project/dlrnapi_client
 description-file =
     README.rst
 long-description-content-type = text/x-rst; charset=UTF-8
@@ -16,14 +19,18 @@ classifier =
     Programming Language :: Python
     Programming Language :: Python :: 2
     Programming Language :: Python :: 2.7
-    Programming Language :: Python :: 2.6
+
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.3
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
 
 [files]
 packages =
     dlrnapi_client
 
+[options]
+python_requires = >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*
 [entry_points]
 console_scripts =
     dlrnapi = dlrnapi_client.shell:main

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34, pep8
+envlist = pep8,py27,py35,py36,py37
 
 [testenv]
 usedevelop = True
@@ -22,4 +22,3 @@ show-source = True
 ignore = E123,E125,H803,F821,W504
 builtins = _
 exclude=.venv,.git,.tox,dist,doc,*openstack/common*,*lib/python*,*egg,build
-


### PR DESCRIPTION
- assure we support py35, py36, py37
- adds missing zuul jobs for testing these
- adds missing metadata for package
- updates trove metadata